### PR TITLE
Last fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "go-ipfs-dep",
+  "name": "npm-go-ipfs-dep",
   "version": "0.4.4",
   "description": "Install the latest go-ipfs binary",
   "go-ipfs": {
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/diasdavid/go-ipfs-dep.git"
+    "url": "git+https://github.com/ipfs/npm-go-ipfs-dep.git"
   },
   "dependencies": {
     "go-platform": "^1.0.0",
@@ -32,9 +32,9 @@
   "author": "Juan Benet <juan@benet.ai> (http://juan.benet.ai/)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/diasdavid/go-ipfs-dep/issues"
+    "url": "https://github.com/ipfs/npm-go-ipfs-dep/issues"
   },
-  "homepage": "https://github.com/diasdavid/go-ipfs-dep",
+  "homepage": "https://github.com/ipfs/npm-go-ipfs-dep",
   "devDependencies": {
     "rimraf": "^2.5.4",
     "tap-spec": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "npm-go-ipfs-dep",
-  "version": "0.4.4",
+  "name": "go-ipfs-dep",
+  "version": "0.4.4-1",
   "description": "Install the latest go-ipfs binary",
   "go-ipfs": {
     "version": "v0.4.4"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,13 @@
   },
   "scripts": {
     "install": "node src/bin.js",
-    "test": "tape test/*.js | tap-spec"
+    "test": "tape test/*.js | tap-spec",
+    "lint": "standard"
   },
+  "pre-commit": [
+    "lint",
+    "test"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ipfs/npm-go-ipfs-dep.git"
@@ -36,7 +41,9 @@
   },
   "homepage": "https://github.com/ipfs/npm-go-ipfs-dep",
   "devDependencies": {
+    "pre-commit": "^1.1.3",
     "rimraf": "^2.5.4",
+    "standard": "^8.6.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.0"
   }

--- a/src/bin.js
+++ b/src/bin.js
@@ -12,7 +12,7 @@ const error = (err) => {
 
 const success = (fileName, installPath) => {
   process.stdout.write(`Downloaded ${fileName}\n`)
-  process.stdout.write(`Installed go-${fileName.replace('.tar.gz', '').replace('.zip', '').replace(/_/g, ' ')} to ${outputPath}\n`)
+  process.stdout.write(`Installed go-${fileName.replace('.tar.gz', '').replace('.zip', '').replace(/_/g, ' ')} to ${installPath}\n`)
   process.exit(1)
 }
 

--- a/src/check-support.js
+++ b/src/check-support.js
@@ -5,8 +5,8 @@
 
 // The packages we support
 const supportedPlatforms = ['linux', 'darwin', 'windows', 'freebsd']
-const supportedArchs     = ['amd64', '386', 'arm']
-const supportedVersions  = [
+const supportedArchs = ['amd64', '386', 'arm']
+const supportedVersions = [
   'sharding-pre',
   'v0.3.2',
   'v0.3.4',
@@ -22,13 +22,13 @@ const supportedVersions  = [
   'v0.4.2',
   'v0.4.3',
   'v0.4.4',
-  'v0.4.5-pre1',
+  'v0.4.5-pre1'
 ]
 
 // Check functions
-const isSupportedVersion  = (version) => supportedVersions.indexOf(version) !== -1
+const isSupportedVersion = (version) => supportedVersions.indexOf(version) !== -1
 const isSupportedPlatform = (platform) => supportedPlatforms.indexOf(platform) !== -1
-const isSupportedArch     = (arch) => supportedArchs.indexOf(arch) !== -1
+const isSupportedArch = (arch) => supportedArchs.indexOf(arch) !== -1
 
 // Is the platform Windows?
 const isWindows = (os) => {
@@ -37,14 +37,15 @@ const isWindows = (os) => {
 
 // Validate the requested binary support, throw en error if not supported
 const verify = (version, platform, arch) => {
-  if (!isSupportedArch(arch))
-    throw new Error(`No binary available for arch '${arch}'`)
+  if (!isSupportedArch(arch)) { throw new Error(`No binary available for arch '${arch}'`) }
 
-  if (!isSupportedPlatform(platform))
+  if (!isSupportedPlatform(platform)) {
     throw new Error(`No binary available for platform '${platform}'`)
+  }
 
-  if (!isSupportedVersion(version))
+  if (!isSupportedVersion(version)) {
     throw new Error(`Version '${version}' not available`)
+  }
 
   return true
 }
@@ -58,5 +59,5 @@ module.exports = {
   isSupportedPlatform: isSupportedPlatform,
   isSupportedArch: isSupportedArch,
   isWindows: isWindows,
-  verify: verify,
+  verify: verify
 }

--- a/src/check-support.js
+++ b/src/check-support.js
@@ -37,7 +37,9 @@ const isWindows = (os) => {
 
 // Validate the requested binary support, throw en error if not supported
 const verify = (version, platform, arch) => {
-  if (!isSupportedArch(arch)) { throw new Error(`No binary available for arch '${arch}'`) }
+  if (!isSupportedArch(arch)) {
+    throw new Error(`No binary available for arch '${arch}'`)
+  }
 
   if (!isSupportedPlatform(platform)) {
     throw new Error(`No binary available for platform '${platform}'`)

--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ function download (version, platform, arch, installPath) {
       }
       // Handle errors
       if (res.statusCode !== 200) {
-        error(new Error(`${res.statusCode} - ${res.body}`), reject)
+        reject(new Error(`${res.statusCode} - ${res.body}`))
       }
     })
     .on('response', (res) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 'use strict'
-/* 
+/*
   Download go-ipfs distribution package for desired version, platform and architecture,
   and unpack it to a desired output directory.
 
@@ -26,27 +26,27 @@ const request = require('request')
 const tarFS = require('tar-fs')
 const unzip = require('unzip')
 const support = require('./check-support')
-const pkg  = require('./../package.json')
+const pkg = require('./../package.json')
 
 // Check package.json for default config
 const goIpfsInfo = pkg['go-ipfs']
 
-const goIpfsVersion = (goIpfsInfo && goIpfsInfo.version) 
+const goIpfsVersion = (goIpfsInfo && goIpfsInfo.version)
   ? pkg['go-ipfs'].version
   : 'v' + pkg.version.replace(/-[0-9]+/, '')
 
-let distUrl = (goIpfsInfo && goIpfsInfo.distUrl) 
-  ? pkg['go-ipfs'].distUrl 
+let distUrl = (goIpfsInfo && goIpfsInfo.distUrl)
+  ? pkg['go-ipfs'].distUrl
   : 'https://dist.ipfs.io'
 
 // Main function
 function download (version, platform, arch, installPath) {
   return new Promise((resolve, reject) => {
     //            Environment Variables           Args        Defaults
-    version     = process.env.TARGET_VERSION   || version  || goIpfsVersion
-    platform    = process.env.TARGET_OS        || platform || goenv.GOOS
-    arch        = process.env.TARGET_ARCH      || arch     || goenv.GOARCH
-    distUrl     = process.env.GO_IPFS_DIST_URL || distUrl
+    version = process.env.TARGET_VERSION || version || goIpfsVersion
+    platform = process.env.TARGET_OS || platform || goenv.GOOS
+    arch = process.env.TARGET_ARCH || arch || goenv.GOARCH
+    distUrl = process.env.GO_IPFS_DIST_URL || distUrl
     installPath = installPath ? path.resolve(installPath) : path.resolve(process.cwd())
 
     // Make sure we support the requested package
@@ -92,14 +92,19 @@ function download (version, platform, arch, installPath) {
     process.stdout.write(`Downloading ${url}\n`)
 
     request.get(url, (err, res, body) => {
+      if (err) {
+        // TODO handle error: haad?
+      }
       // Handle errors
-      if (res.statusCode !== 200)
+      if (res.statusCode !== 200) {
         error(new Error(`${res.statusCode} - ${res.body}`), reject)
+      }
     })
     .on('response', (res) => {
       // Unpack only if the request was successful
-      if (res.statusCode !== 200)
-        return 
+      if (res.statusCode !== 200) {
+        return
+      }
 
       unpack(res)
     })

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,8 @@ const rimraf = require('rimraf')
 const goenv = require('go-platform')
 const pkg = require('./../package.json')
 const Download = require('../src')
-const version = process.env.TARGET_VERSION || 'v' + pkg.version
+
+const version = process.env.TARGET_VERSION || 'v' + pkg.version.replace(/-[0-9]+/, '')
 
 // These tests won't work with promises, wrap the download function to a callback
 const download = (version, platform, arch, callback) => {
@@ -38,7 +39,7 @@ const download = (version, platform, arch, callback) => {
 }
 
 test('Ensure ipfs gets downloaded (current version and platform)', (t) => {
-  t.plan(4)
+  t.plan(5)
   const dir = path.resolve(__dirname, '../go-ipfs')
   rimraf.sync(dir)
   download((err, res) => {
@@ -54,7 +55,7 @@ test('Ensure ipfs gets downloaded (current version and platform)', (t) => {
 })
 
 test('Ensure Windows version gets downloaded', (t) => {
-  t.plan(6)
+  t.plan(7)
   const dir = path.resolve(__dirname, '../go-ipfs')
   rimraf.sync(dir)
   download(version, 'windows', (err, res) => {
@@ -75,7 +76,7 @@ test('Ensure Windows version gets downloaded', (t) => {
 })
 
 test('Ensure Linux version gets downloaded', (t) => {
-  t.plan(6)
+  t.plan(7)
   const dir = path.resolve(__dirname, '../go-ipfs')
   rimraf.sync(dir)
   download(version, 'linux', (err, res) => {
@@ -96,7 +97,7 @@ test('Ensure Linux version gets downloaded', (t) => {
 })
 
 test('Ensure OSX version gets downloaded', (t) => {
-  t.plan(6)
+  t.plan(7)
   const dir = path.resolve(__dirname, '../go-ipfs')
   rimraf.sync(dir)
   download(version, 'darwin', (err, res) => {
@@ -117,7 +118,7 @@ test('Ensure OSX version gets downloaded', (t) => {
 })
 
 test('Ensure TARGET_OS, TARGET_VERSION and TARGET_ARCH version gets downloaded', (t) => {
-  t.plan(6)
+  t.plan(7)
   const dir = path.resolve(__dirname, '../go-ipfs')
   rimraf.sync(dir)
   process.env.TARGET_OS = 'windows'

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ const version = process.env.TARGET_VERSION || 'v' + pkg.version
 
 // These tests won't work with promises, wrap the download function to a callback
 const download = (version, platform, arch, callback) => {
- if (typeof version === 'function' || !version) {
+  if (typeof version === 'function' || !version) {
     callback = version || callback
     version = null
   }
@@ -26,7 +26,11 @@ const download = (version, platform, arch, callback) => {
     arch = null
   }
 
-  callback = callback || ((err, res) => {})
+  callback = callback || ((err, res) => {
+    if (err) {
+      throw err
+    }
+  })
 
   Download(version, platform, arch)
     .then((e) => callback(null, e))
@@ -38,6 +42,7 @@ test('Ensure ipfs gets downloaded (current version and platform)', (t) => {
   const dir = path.resolve(__dirname, '../go-ipfs')
   rimraf.sync(dir)
   download((err, res) => {
+    t.ifErr(err)
     t.ok(res.file.indexOf(`ipfs_${version}_${goenv.GOOS}-${goenv.GOARCH}`) !== -1, 'Returns the correct filename')
     t.ok(res.dir === path.resolve(__dirname, '../', 'go-ipfs') + '/', 'Returns the correct output path')
 
@@ -53,6 +58,7 @@ test('Ensure Windows version gets downloaded', (t) => {
   const dir = path.resolve(__dirname, '../go-ipfs')
   rimraf.sync(dir)
   download(version, 'windows', (err, res) => {
+    t.ifErr(err)
     t.ok(res.file.indexOf(`ipfs_${version}_windows-${goenv.GOARCH}`) !== -1, 'Returns the correct filename')
     t.ok(res.dir === path.resolve(__dirname, '../', 'go-ipfs') + '/', 'Returns the correct output path')
 
@@ -73,6 +79,7 @@ test('Ensure Linux version gets downloaded', (t) => {
   const dir = path.resolve(__dirname, '../go-ipfs')
   rimraf.sync(dir)
   download(version, 'linux', (err, res) => {
+    t.ifErr(err)
     t.ok(res.file.indexOf(`ipfs_${version}_linux-${goenv.GOARCH}`) !== -1, 'Returns the correct filename')
     t.ok(res.dir === path.resolve(__dirname, '../', 'go-ipfs') + '/', 'Returns the correct output path')
 
@@ -93,6 +100,7 @@ test('Ensure OSX version gets downloaded', (t) => {
   const dir = path.resolve(__dirname, '../go-ipfs')
   rimraf.sync(dir)
   download(version, 'darwin', (err, res) => {
+    t.ifErr(err)
     t.ok(res.file.indexOf(`ipfs_${version}_darwin-${goenv.GOARCH}`) !== -1, 'Returns the correct filename')
     t.ok(res.dir === path.resolve(__dirname, '../', 'go-ipfs') + '/', 'Returns the correct output path')
 
@@ -116,6 +124,7 @@ test('Ensure TARGET_OS, TARGET_VERSION and TARGET_ARCH version gets downloaded',
   process.env.TARGET_VERSION = version
   process.env.TARGET_ARCH = '386'
   download((err, res) => {
+    t.ifErr(err)
     t.ok(res.file.indexOf(`ipfs_${process.env.TARGET_VERSION}_${process.env.TARGET_OS}-${process.env.TARGET_ARCH}`) !== -1, 'Returns the correct filename')
     t.ok(res.dir === path.resolve(__dirname, '../', 'go-ipfs') + '/', 'Returns the correct output path')
 

--- a/test/index.js
+++ b/test/index.js
@@ -153,3 +153,15 @@ test('Returns an error when version unsupported', (t) => {
     t.ok(err.toString() === "Error: Version 'bogusversion' not available", 'Throws the correct error message')
   })
 })
+
+test('Returns an error when dist url is 404', (t) => {
+  t.plan(2)
+  const dir = path.resolve(__dirname, '../go-ipfs')
+  rimraf.sync(dir)
+  process.env.GO_IPFS_DIST_URL = 'https://dist.ipfs.io/notfound'
+  download((err, res) => {
+    t.ok(err !== null, 'Throws an error')
+    t.ok(err.toString().indexOf('Error: 404 - Path Resolve error: no link named "notfound" under') > -1, 'Throws the correct error message')
+    delete process.env.GO_IPFS_DIST_URL
+  })
+})


### PR DESCRIPTION
Found and fixed a bunch of linting problem (things like 3 spaces indentation and errors not being handled), added standard as a base linter.

Still missing:

```bash
standard: Use JavaScript Standard Style (http://standardjs.com)
  /Users/imp/code/npm-go-ipfs-dep/src/bin.js:15:117: 'outputPath' is not defined.
  /Users/imp/code/npm-go-ipfs-dep/src/index.js:100:9: 'error' is not defined.
```

Both of them would cause problems for users.

Then, once I updated the version to be 0.4.4-1, tests started failing, although I didn't update the go-ipfs value in the package.json. Did the `-N` cleaning got removed? 