### PR TITLE
go-ipfs 0.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "go-ipfs-dep",
-  "version": "0.4.4-1",
+  "version": "0.4.5",
   "description": "Install the latest go-ipfs binary",
   "go-ipfs": {
-    "version": "v0.4.4"
+    "version": "v0.4.5"
   },
   "main": "src/index.js",
   "engines": {

--- a/src/check-support.js
+++ b/src/check-support.js
@@ -22,7 +22,7 @@ const supportedVersions = [
   'v0.4.2',
   'v0.4.3',
   'v0.4.4',
-  'v0.4.5-pre1'
+  'v0.4.5'
 ]
 
 // Check functions


### PR DESCRIPTION
This PR will change the go-ipfs version from 0.4.4 to 0.4.5