### PR TITLE
chore: reject promise with error when encountered

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,6 +97,7 @@ function download (version, platform, arch, installPath) {
     request.get(url, (err, res, body) => {
       if (err) {
         // TODO handle error: haad?
+        return reject(err)
       }
       // Handle errors
       if (res.statusCode !== 200) {


### PR DESCRIPTION
Otherwise you get this sort of thing which is less helpful:

```
      if (res.statusCode !== 200) {
              ^

TypeError: Cannot read property 'statusCode' of undefined
```