### PR TITLE
fix: use go-ipfs.version from parent package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-Install go-ipfs from npm as a dependency of your project
-========================================================
+# go-ipfs-dep
 
+> Download [go-ipfs](https://github.com/ipfs/go-ipfs/) to your node_modules.
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
@@ -8,7 +8,6 @@ Install go-ipfs from npm as a dependency of your project
 [![Travis CI](https://flat.badgen.net/travis/ipfs/npm-go-ipfs-dep)](https://travis-ci.com/ipfs/npm-go-ipfs-dep)
 [![Dependency Status](https://david-dm.org/ipfs/npm-go-ipfs.svg?style=flat-square)](https://david-dm.org/ipfs/npm-go-ipfs)
 
-> Install the latest [go-ipfs](https://github.com/ipfs/go-ipfs/) binary from [http://dist.ipfs.io](http://dist.ipfs.io)
 
 # Installation
 
@@ -18,13 +17,15 @@ npm install go-ipfs-dep --save
 
 See [IPFS getting-started](http://ipfs.io/docs/getting-started). If anything goes wrong, try using: [http://ipfs.io/docs/install](http://ipfs.io/docs/install).
 
-## Development
+## Usage
 
-**Warning**: The binary gets put in the `go-ipfs` folder inside the module folder.
+This module downloads `go-ipfs` binaries from https://dist.ipfs.io into your project.
 
-### Which go-ipfs version this package downloads?
+By default it will download the go-ipfs version that matches the npm version of this module. So depending on `go-ipfs-dep@0.4.19` will install `go-ipfs v0.4.19` for your current system architecture, in to your project at `node_modules/go-ipfs-dep/go-ipfs/ipfs`.
 
-Can be specified in `package.json` with a field `go-ipfs.version`, eg:
+### Overriding the go-ipfs version
+
+You can override the version of go-ipfs that gets downloaded by adding by adding a `go-ipfs.version` field to your `package.json`
 
 ```json
 "go-ipfs": {
@@ -33,7 +34,8 @@ Can be specified in `package.json` with a field `go-ipfs.version`, eg:
 ```
 
 ### Using local IPFS daemon as the package download url
-Can be specified in `package.json` with a field `go-ipfs.version`, eg:
+
+The url to download the binaries from can be specified by adding a field `go-ipfs.distUrl` field to your `package.json`, eg:
 
 ```json
 "go-ipfs": {
@@ -65,6 +67,10 @@ node src/bin.js <version> <platform> <architecture> <install directory>
 ```
 node src/bin.js v0.4.3 linux amd64 ./go-ipfs
 ```
+
+## Development
+
+**Note**: The binary gets put in the `go-ipfs` folder inside the module folder.
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "homepage": "https://github.com/ipfs/npm-go-ipfs-dep",
   "devDependencies": {
     "aegir": "^18.2.0",
-    "rimraf": "^2.6.2",
+    "execa": "^1.0.0",
+    "rimraf": "^2.6.3",
     "standard": "^12.0.1",
     "tap-spec": "^5.0.0",
     "tape": "^4.9.1"
@@ -49,6 +50,7 @@
     "Haad <haadcode@users.noreply.github.com>",
     "Harlan T Wood <harlantwood@users.noreply.github.com>",
     "Henrique Dias <hacdias@gmail.com>",
+    "Oli Evans <oli@tableflip.io>",
     "Scott Hardy <scott.the.hardy@gmail.com>",
     "Stephen Whitmore <stephen.whitmore@gmail.com>",
     "haad <haad@headbanggames.com>"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "go-platform": "^1.0.0",
     "gunzip-maybe": "^1.4.1",
     "node-fetch": "^2.3.0",
+    "pkg-conf": "^3.1.0",
     "tar-fs": "^2.0.0",
     "unzip-stream": "^0.3.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ async function download ({ installPath, url }) {
   return unpack({ url, installPath, stream: res.body })
 }
 
-async function cleanArguments (version, platform, arch, installPath) {
+function cleanArguments (version, platform, arch, installPath) {
   const conf = pkgConf.sync('go-ipfs', {
     cwd: path.join(process.cwd(), '..'),
     defaults: {

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const path = require('path')
 const tarFS = require('tar-fs')
 const unzip = require('unzip-stream')
 const fetch = require('node-fetch')
+const pkgConf = require('pkg-conf')
 const pkg = require('./../package.json')
 
 function unpack ({ url, installPath, stream }) {
@@ -55,22 +56,19 @@ async function download ({ installPath, url }) {
   return unpack({ url, installPath, stream: res.body })
 }
 
-function cleanArguments (version, platform, arch, installPath) {
-  const goIpfsInfo = pkg['go-ipfs']
-
-  const goIpfsVersion = (goIpfsInfo && goIpfsInfo.version)
-    ? pkg['go-ipfs'].version
-    : 'v' + pkg.version.replace(/-[0-9]+/, '')
-
-  const distUrl = (goIpfsInfo && goIpfsInfo.distUrl)
-    ? pkg['go-ipfs'].distUrl
-    : 'https://dist.ipfs.io'
-
+async function cleanArguments (version, platform, arch, installPath) {
+  const conf = pkgConf.sync('go-ipfs', {
+    cwd: path.join(process.cwd(), '..'),
+    defaults: {
+      version: 'v' + pkg.version.replace(/-[0-9]+/, ''),
+      distUrl: 'https://dist.ipfs.io'
+    }
+  })
   return {
-    version: process.env.TARGET_VERSION || version || goIpfsVersion,
+    version: process.env.TARGET_VERSION || version || conf.version,
     platform: process.env.TARGET_OS || platform || goenv.GOOS,
     arch: process.env.TARGET_ARCH || arch || goenv.GOARCH,
-    distUrl: process.env.GO_IPFS_DIST_URL || distUrl,
+    distUrl: process.env.GO_IPFS_DIST_URL || conf.distUrl,
     installPath: installPath ? path.resolve(installPath) : process.cwd()
   }
 }
@@ -105,7 +103,7 @@ async function getDownloadURL ({ version, platform, arch, distUrl }) {
 }
 
 module.exports = async function () {
-  const args = cleanArguments(...arguments)
+  const args = await cleanArguments(...arguments)
   const url = await getDownloadURL(args)
 
   process.stdout.write(`Downloading ${url}\n`)

--- a/test/fixture/example-project/package.json
+++ b/test/fixture/example-project/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "",
+  "license": "ISC",
+  "go-ipfs": {
+    "version": "v0.4.21-rc3"
+  }
+}

--- a/test/install.js
+++ b/test/install.js
@@ -1,0 +1,43 @@
+const fs = require('fs')
+const path = require('path')
+const test = require('tape')
+const execa = require('execa')
+const rimraf = require('rimraf')
+
+/*
+  Test that go-ipfs is downloaded during npm install.
+  - package up the current source code with `npm pack`
+  - install the tarball into the example project
+  - ensure that the "go-ipfs.version" prop in the package.json is used
+*/
+
+const testVersion = 'v0.4.21-rc3'
+let tarballName = null
+
+function packTarball () {
+  try {
+    const parentDir = path.join(__dirname, '..')
+    const res = execa.sync('npm', ['pack', parentDir], {
+      cwd: __dirname
+    })
+    tarballName = res.stdout
+    return tarballName
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+test.onFinish(() => {
+  fs.unlinkSync(path.join(__dirname, tarballName))
+})
+
+test('Ensure go-ipfs.version defined in parent package.json is used', async (t) => {
+  rimraf.sync(path.join('fixture', 'example-project', 'node_modules'))
+  const tarballName = packTarball()
+  // from `example-project`, install the module
+  const res = execa.sync('npm', ['install', '--no-save', path.join('..', '..', tarballName)], {
+    cwd: path.join(__dirname, 'fixture', 'example-project')
+  })
+  t.ok(res.stdout.includes(`Downloading https://dist.ipfs.io/go-ipfs/${testVersion}`))
+  t.end()
+})

--- a/test/install.js
+++ b/test/install.js
@@ -28,7 +28,7 @@ test.onFinish(() => {
   rimraf.sync(path.join('fixture', 'example-project', 'node_modules'))
 })
 
-test.only('Ensure go-ipfs.version defined in parent package.json is used', (t) => {
+test('Ensure go-ipfs.version defined in parent package.json is used', (t) => {
   const tarballName = packTarball()
   // from `example-project`, install the module
   const res = execa.sync('npm', ['install', '--no-save', path.join('..', '..', tarballName)], {

--- a/test/install.js
+++ b/test/install.js
@@ -11,33 +11,30 @@ const rimraf = require('rimraf')
   - ensure that the "go-ipfs.version" prop in the package.json is used
 */
 
-const testVersion = 'v0.4.21-rc3'
+const testVersion = require('./fixture/example-project/package.json')['go-ipfs'].version
 let tarballName = null
 
 function packTarball () {
-  try {
-    const parentDir = path.join(__dirname, '..')
-    const res = execa.sync('npm', ['pack', parentDir], {
-      cwd: __dirname
-    })
-    tarballName = res.stdout
-    return tarballName
-  } catch (err) {
-    console.error(err)
-  }
+  const parentDir = path.join(__dirname, '..')
+  const res = execa.sync('npm', ['pack', parentDir], {
+    cwd: __dirname
+  })
+  tarballName = res.stdout
+  return tarballName
 }
 
 test.onFinish(() => {
   fs.unlinkSync(path.join(__dirname, tarballName))
+  rimraf.sync(path.join('fixture', 'example-project', 'node_modules'))
 })
 
-test('Ensure go-ipfs.version defined in parent package.json is used', async (t) => {
-  rimraf.sync(path.join('fixture', 'example-project', 'node_modules'))
+test.only('Ensure go-ipfs.version defined in parent package.json is used', (t) => {
   const tarballName = packTarball()
   // from `example-project`, install the module
   const res = execa.sync('npm', ['install', '--no-save', path.join('..', '..', tarballName)], {
     cwd: path.join(__dirname, 'fixture', 'example-project')
   })
-  t.ok(res.stdout.includes(`Downloading https://dist.ipfs.io/go-ipfs/${testVersion}`))
+  const msg = `Downloading https://dist.ipfs.io/go-ipfs/${testVersion}`
+  t.ok(res.stdout.includes(msg), msg)
   t.end()
 })


### PR DESCRIPTION
- use [pkg-conf](https://github.com/sindresorhus/pkg-conf#readme) to fetch `go-ipfs` config from a parent package.json rather than checking for it in _this_ modules package.json
- add test to check `go-ipfs.version` is used during npm install

fixes #33

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>