### PR TITLE
feat: print progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "go-platform": "^1.0.0",
     "gunzip-maybe": "^1.4.1",
     "node-fetch": "^2.3.0",
+    "node-fetch-progress": "^1.0.2",
     "pkg-conf": "^3.1.0",
     "tar-fs": "^2.0.0",
     "unzip-stream": "^0.3.0"

--- a/src/bin.js
+++ b/src/bin.js
@@ -5,14 +5,13 @@
 const download = require('./')
 
 const error = (err) => {
-  process.stdout.write(`${err}\n`)
-  process.stdout.write(`Download failed!\n\n`)
+  process.stdout.write(`❌ ${err}\n`)
   process.exit(1)
 }
 
 const success = (output) => {
-  process.stdout.write(`Downloaded ${output.fileName}\n`)
-  process.stdout.write(`Installed go-${output.fileName.replace('.tar.gz', '').replace('.zip', '').replace(/_/g, ' ')} to ${output.installPath}\n`)
+  process.stdout.write(`📦 Downloaded ${output.fileName}\n`)
+  process.stdout.write(`🤖 Installed go-${output.fileName.replace('.tar.gz', '').replace('.zip', '').replace(/_/g, ' ')} to ${output.installPath}\n`)
   process.exit(0)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const path = require('path')
 const tarFS = require('tar-fs')
 const unzip = require('unzip-stream')
 const fetch = require('node-fetch')
+const Progress = require('node-fetch-progress')
 const pkgConf = require('pkg-conf')
 const pkg = require('./../package.json')
 
@@ -50,9 +51,29 @@ function unpack ({ url, installPath, stream }) {
   })
 }
 
+function progressFetch (res) {
+  const progress = new Progress(res, { throttle: 100 })
+
+  return new Promise((resolve) => {
+    progress.on('progress', (p) => {
+      process.stdout.clearLine()
+      process.stdout.cursorTo(0)
+
+      const prog = Math.floor(p.progress * 100)
+
+      process.stdout.write(`🌟 ${prog}% ${prog === 100 ? '\n' : ''}`)
+
+      if (prog === 100) {
+        resolve()
+      }
+    })
+  })
+}
+
 async function download ({ installPath, url }) {
   const res = await fetch(url)
   if (!res.ok) throw new Error(`Unexpected status: ${res.status}`)
+  await progressFetch(res)
   return unpack({ url, installPath, stream: res.body })
 }
 
@@ -74,6 +95,7 @@ function cleanArguments (version, platform, arch, installPath) {
 }
 
 async function ensureVersion ({ version, distUrl }) {
+  process.stdout.write('🦄 Fetching go-ipfs version list\n')
   const res = await fetch(`${distUrl}/go-ipfs/versions`)
   if (!res.ok) throw new Error(`Unexpected status: ${res.status}`)
   const versions = (await res.text()).trim().split('\n')
@@ -86,6 +108,7 @@ async function ensureVersion ({ version, distUrl }) {
 async function getDownloadURL ({ version, platform, arch, distUrl }) {
   await ensureVersion({ version, distUrl })
 
+  process.stdout.write(`🦄 Fetching go-ipfs ${version} information\n`)
   const res = await fetch(`${distUrl}/go-ipfs/${version}/dist.json`)
   if (!res.ok) throw new Error(`Unexpected status: ${res.status}`)
   const data = await res.json()
@@ -106,7 +129,7 @@ module.exports = async function () {
   const args = await cleanArguments(...arguments)
   const url = await getDownloadURL(args)
 
-  process.stdout.write(`Downloading ${url}\n`)
+  process.stdout.write(`📦 Downloading ${url}\n`)
 
   await download({ ...args, url })
 


### PR DESCRIPTION
[IPFS Desktop](https://github.com/ipfs-shipyard/ipfs-desktop) builds have been failing on Travis due to 10 minutes without output when downloading IPFS. It seems `dist.ipfs.io` is being too slow to provide a response. I thought it would be a great idea to introduce some kind of progress so we always print something and avoid failures due to no output.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>