### PR TITLE
fix: ensure test points at a stable release

### DIFF
--- a/test/fixture/example-project/package.json
+++ b/test/fixture/example-project/package.json
@@ -6,6 +6,6 @@
   "author": "",
   "license": "ISC",
   "go-ipfs": {
-    "version": "v0.4.21-rc3"
+    "version": "v0.4.20"
   }
 }


### PR DESCRIPTION
we've been removing release candidates from dist, so the
test was failing becuase it could no longer download the
version it was pointing at.

this PR updates the test to point to a stable release
that is likely to be available

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>