### PR TITLE
fix: automated publish

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,5 +1,7 @@
 workflow "Release to npm" {
-  on = "schedule(0 */1 * * *)"
+  on:
+    schedule:
+      - cron:  "0 */1 * * *"
   resolves = ["Version and publish"]
 }
 


### PR DESCRIPTION
I think the syntax for scheduling jobs may have changed.

Ref: https://help.github.com/en/actions/reference/events-that-trigger-workflows