### PR TITLE
docs: add deprecation warning to top of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# ⛔️ DEPRECATED: the `go-ipfs` module is a drop-in replacement for `go-ipfs-dep`, please use that instead
+# ⛔️ DEPRECATED
+
+The [`go-ipfs`](https://github.com/ipfs/npm-go-ipfs) module is a drop-in replacement, please use that instead
+
+_This library will not be maintained._
+
+----
 
 # go-ipfs-dep
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# ⛔️ DEPRECATED: the `go-ipfs` module is a drop-in replacement for `go-ipfs-dep`, please use that instead
+
 # go-ipfs-dep
 
 > Download [go-ipfs](https://github.com/ipfs/go-ipfs/) to your node_modules.


### PR DESCRIPTION
Since we can now use `go-ipfs` in place of this module it doesn't make sense to keep both around.